### PR TITLE
Incorrect payment status on cancel payment

### DIFF
--- a/server/services/dynamics-service.js
+++ b/server/services/dynamics-service.js
@@ -666,7 +666,7 @@ async function setPaymentReference (params) {
     const url = `${apiUrl}cites_submissions(${params.submissionId})`
 
     let requestPayload = {
-      statuscode: 149900002
+      statuscode: 1
     }
 
     if (params.isAdditionalPayment) {


### PR DESCRIPTION
On cancel Payment the status was showing inProgress instead of awaiting payment.
Fix is done.
